### PR TITLE
Fix cloudant service instance env var

### DIFF
--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -46,7 +46,7 @@ services:
           BUILD_SCRIPTS: 'pipeline-BLOCKCHAIN.sh pipeline-BUILD.sh pipeline-CLOUDANT.sh pipeline-COMMON.sh pipeline-DEPLOY.sh'
           SAMPLE_REPO: sample-repo
           BLOCKCHAIN_SERVICE_INSTANCE: '{{form.pipeline.parameters.blockchain-service-instance}}'
-          CLOUDANT_SERVICE_INSTANCE: '{{form.pipeline.parameters.blockchain-service-instance}}'
+          CLOUDANT_SERVICE_INSTANCE: '{{form.pipeline.parameters.cloudant-service-instance}}'
           APP_NAME: '{{form.pipeline.parameters.deploy-app-name}}'
           REGION_ID: '{{form.pipeline.parameters.deploy-region}}'
           ORG_NAME: '{{form.pipeline.parameters.deploy-organization}}'


### PR DESCRIPTION
The CLOUDANT_SERVICE_INSTANCE env var in the e2e toolchain
template was picking up the value of the blockchain service
instance instead of the cloudant service instance on the
pipeline form

Closes #16

Signed-off-by: James Taylor <jamest@uk.ibm.com>