### PR TITLE
Add stage1 support

### DIFF
--- a/.bluemix/pipeline.yml
+++ b/.bluemix/pipeline.yml
@@ -48,6 +48,9 @@ stages:
   triggers:
   - type: stage
   properties:
+  - name: REGION_ID
+    value: ${REGION_ID}
+    type: text
   - name: SCRIPT_DIR
     value: ${SCRIPT_DIR}
     type: text


### PR DESCRIPTION
Deploy script requires the region ID in order to use alternative
service details when running on stage1

Closes IBM-Blockchain-Starter-Kit/build-lib#7

Signed-off-by: James Taylor <jamest@uk.ibm.com>