### PR TITLE
Update sample-build-lib version

### DIFF
--- a/.bluemix/pipeline.yml
+++ b/.bluemix/pipeline.yml
@@ -12,7 +12,7 @@ stages:
     value: ${SCRIPT_DIR}
     type: text
   - name: BUILD_LIB_URL
-    value: 'https://github.com/IBM-Blockchain-Starter-Kit/build-lib/releases/download/v0.1-preview1/sample-blockchain-build-lib.tgz'
+    value: 'https://github.com/IBM-Blockchain-Starter-Kit/build-lib/releases/download/v0.2.1/sample-blockchain-build-lib.tgz'
     type: text
   jobs:
   - name: Prepare


### PR DESCRIPTION
Support Fabric 1.2 but updating build scripts to v0.2.1

Signed-off-by: James Taylor <jamest@uk.ibm.com>