### PR TITLE
Update build-lib version

### DIFF
--- a/.bluemix/cc-pipeline.yml
+++ b/.bluemix/cc-pipeline.yml
@@ -12,7 +12,7 @@ stages:
     value: ${SCRIPT_DIR}
     type: text
   - name: BUILD_LIB_URL
-    value: 'https://github.com/IBM-Blockchain-Starter-Kit/build-lib/releases/download/v0.3/blockchain-build-lib.tgz'
+    value: 'https://github.com/IBM-Blockchain-Starter-Kit/build-lib/releases/download/v0.3.1/blockchain-build-lib.tgz'
     type: text
   jobs:
   - name: Prepare


### PR DESCRIPTION
Support Fabric 1.2 by updating build scripts to v0.3.1

Contributes to #IBM-Blockchain-Starter-Kit/build-lib#78

Signed-off-by: James Taylor <jamest@uk.ibm.com>