### PR TITLE
updated cc-pipeline.yml so it points to the latest release of build-lib

### DIFF
--- a/.bluemix/cc-pipeline.yml
+++ b/.bluemix/cc-pipeline.yml
@@ -12,7 +12,7 @@ stages:
     value: ${SCRIPT_DIR}
     type: text
   - name: BUILD_LIB_URL
-    value: 'https://github.com/IBM-Blockchain-Starter-Kit/build-lib/releases/download/v0.3.1/blockchain-build-lib.tgz'
+    value: 'https://github.com/IBM-Blockchain-Starter-Kit/build-lib/releases/download/v0.4/blockchain-build-lib.tgz'
     type: text
   jobs:
   - name: Prepare


### PR DESCRIPTION
@jt-nti Can you review and merge this PR? The pipeline file was referencing an old version of build-lib.